### PR TITLE
feat: openapi swagger 의존성 추가 및 설정 (#6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/SwaggerConfig.java
+++ b/src/main/java/SwaggerConfig.java
@@ -1,0 +1,14 @@
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "LINKIT API Documentation",
+                description = "LINKIT API 명세 페이지입니다.",
+                version = "v1"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+}

--- a/src/main/java/com/kw/LinkIt/LinkItApplication.java
+++ b/src/main/java/com/kw/LinkIt/LinkItApplication.java
@@ -2,8 +2,12 @@ package com.kw.LinkIt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+/**
+ * DataSourceAutoConfiguration : DB 설정 시 삭제 후 application.properties 지정해줘야 한다.
+ */
+@SpringBootApplication(exclude={DataSourceAutoConfiguration.class})
 public class LinkItApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
에러 수정 및 Swagger 연동

## 📋 변경 사항
- Fix : LinkItApplication class에 Annotation 추가 (dependency 충돌로 인해 서버 실행이 안돼서, 무시해주는 어노테이션 추가. 추후 DB 연결 시에는 해당 어노테이션을 삭제해야 한다.)
- Feature : OpenAPI Swagger 의존성 설치 및 설정 완료.

## 🔥 연결된 이슈 Close
추후 세부설정 후 Closing 예정
