### PR TITLE
Fix: ErrorCode 인터페이스를 사용하도록 변경 (#12)

### DIFF
--- a/src/main/java/com/kw/LinkIt/global/error/exception/BusinessException.java
+++ b/src/main/java/com/kw/LinkIt/global/error/exception/BusinessException.java
@@ -1,6 +1,6 @@
 package com.kw.LinkIt.global.error.exception;
 
-import com.kw.LinkIt.global.error.code.CommonErrorCode;
+import com.kw.LinkIt.global.error.code.ErrorCode;
 import com.kw.LinkIt.global.error.response.ErrorResponse;
 import lombok.Getter;
 
@@ -10,22 +10,22 @@ import java.util.List;
 @Getter
 public class BusinessException extends RuntimeException {
 
-    private CommonErrorCode commonErrorCode;
+    private ErrorCode errorCode;
     private List<ErrorResponse.CustomFieldError> errors = new ArrayList<>();
 
-    public BusinessException(CommonErrorCode commonErrorCode, String message) {
+    public BusinessException(ErrorCode errorCode, String message) {
         super(message);
-        this.commonErrorCode = commonErrorCode;
+        this.errorCode = errorCode;
     }
 
-    public BusinessException(CommonErrorCode commonErrorCode) {
-        super(commonErrorCode.getMessage());
-        this.commonErrorCode = commonErrorCode;
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 
-    public BusinessException(CommonErrorCode commonErrorCode, List<ErrorResponse.CustomFieldError> errors) {
-        super(commonErrorCode.getMessage());
-        this.commonErrorCode = commonErrorCode;
+    public BusinessException(ErrorCode errorCode, List<ErrorResponse.CustomFieldError> errors) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
         this.errors = errors;
     }
 }

--- a/src/main/java/com/kw/LinkIt/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kw/LinkIt/global/error/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.kw.LinkIt.global.error.handler;
 
 import com.kw.LinkIt.global.error.code.CommonErrorCode;
+import com.kw.LinkIt.global.error.code.ErrorCode;
 import com.kw.LinkIt.global.error.exception.BusinessException;
 import com.kw.LinkIt.global.error.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -63,9 +64,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.error("BusinessException", e);
-        CommonErrorCode commonErrorCode = e.getCommonErrorCode();
-        final ErrorResponse response = ErrorResponse.of(commonErrorCode);
-        return new ResponseEntity<>(response, commonErrorCode.getStatus());
+        ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/kw/LinkIt/global/error/response/ErrorResponse.java
+++ b/src/main/java/com/kw/LinkIt/global/error/response/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.kw.LinkIt.global.error.response;
 
 import com.kw.LinkIt.global.error.code.CommonErrorCode;
+import com.kw.LinkIt.global.error.code.ErrorCode;
 import jakarta.validation.ConstraintViolation;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,37 +24,37 @@ public class ErrorResponse {
     private String message;
     private List<CustomFieldError> errors;
 
-    private ErrorResponse(final CommonErrorCode commonErrorCode) {
-        this.status = commonErrorCode.getStatus();
-        this.code = commonErrorCode.getCode();
-        this.message = commonErrorCode.getMessage();
+    private ErrorResponse(final ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
         this.errors = new ArrayList<>();
     }
 
-    private ErrorResponse(final CommonErrorCode commonErrorCode, final List<CustomFieldError> errors) {
-        this.status = commonErrorCode.getStatus();
-        this.code = commonErrorCode.getCode();
-        this.message = commonErrorCode.getMessage();
+    private ErrorResponse(final ErrorCode errorCode, final List<CustomFieldError> errors) {
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
         this.errors = errors;
     }
 
-    public static ErrorResponse of(final CommonErrorCode commonErrorCode, final BindingResult bindingResult) {
-        return new ErrorResponse(commonErrorCode, CustomFieldError.of(bindingResult));
+    public static ErrorResponse of(final ErrorCode errorCode, final BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, CustomFieldError.of(bindingResult));
     }
 
-    public static ErrorResponse of(final CommonErrorCode commonErrorCode, final Set<ConstraintViolation<?>> constraintViolations) {
-        return new ErrorResponse(commonErrorCode, CustomFieldError.of(constraintViolations));
+    public static ErrorResponse of(final ErrorCode errorCode, final Set<ConstraintViolation<?>> constraintViolations) {
+        return new ErrorResponse(errorCode, CustomFieldError.of(constraintViolations));
     }
 
-    public static ErrorResponse of(final CommonErrorCode commonErrorCode, final String missingParameterName) {
-        return new ErrorResponse(commonErrorCode, CustomFieldError.of(missingParameterName, "", "parameter must required"));
+    public static ErrorResponse of(final ErrorCode errorCode, final String missingParameterName) {
+        return new ErrorResponse(errorCode, CustomFieldError.of(missingParameterName, "", "parameter must required"));
     }
 
-    public static ErrorResponse of(final CommonErrorCode commonErrorCode) {
-        return new ErrorResponse(commonErrorCode);
+    public static ErrorResponse of(final ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
     }
 
-    public static ErrorResponse of(final CommonErrorCode code, final List<CustomFieldError> errors) {
+    public static ErrorResponse of(final ErrorCode code, final List<CustomFieldError> errors) {
         return new ErrorResponse(code, errors);
     }
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 에러처리 기능 구현 시 ErrorCode 인터페이스를 통해 하위 구현체들에 접근할 수 있도록 수정합니다.

## 📋 변경 사항
- `BusinessException`
- `ErrorResponse`
- `GlobalExceptionHandler`

## 🔥 연결된 이슈 Close
close #12

