### PR TITLE
Feat: 로그인 구현 전까지 모든 url 접근 허용 (#18)

### DIFF
--- a/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.kw.LinkIt.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .httpBasic().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .anyRequest().permitAll();
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- swagger 문서 확인 및 mock api 연동을 위해, 로그인 구현 전까지 모든 엔드포인트에 접근을 허용합니다.

## 📋 변경 사항
- `SecurityConfig`

## 🔥 연결된 이슈 Close

