### PR TITLE
Feat: Hashtag API 구현 (#23)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.0.12'
-	id 'io.spring.dependency-management' version '1.1.3'
+	id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com.kw'
@@ -26,16 +26,27 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 	// Feign Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.8'
+
 	// Jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	// QueryDsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
 
 	// com.sun.xml.bind
 	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
 	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+
 	// javax.xml.bind
 	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 

--- a/src/main/java/com/kw/LinkIt/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kw/LinkIt/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.kw.LinkIt.domain.auth.dto.response.TokenVO;
 import com.kw.LinkIt.domain.auth.service.AuthServiceImpl;
 import com.kw.LinkIt.domain.user.entity.User;
 import com.kw.LinkIt.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,12 +24,14 @@ public class AuthController {
 
     private final AuthServiceImpl authService;
 
+    @Operation(summary = "유저 회원가입")
     @PostMapping("/sign-up")
     public ResponseEntity<String> signUp(@RequestBody @Valid SignUpDTO signUpDTO) {
         authService.signUp(signUpDTO);
         return BaseResponse.ok("회원가입 완료");
     }
 
+    @Operation(summary = "유저 로그인")
     @PostMapping("/login")
     public ResponseEntity<TokenVO> login(@RequestBody LoginDTO loginDTO) {
         System.out.println("---- loginReq uid : " + loginDTO.getUid());

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -2,11 +2,15 @@ package com.kw.LinkIt.domain.hashtag.controller;
 
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
+import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import com.kw.LinkIt.domain.hashtag.service.HashtagService;
 import com.kw.LinkIt.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -19,17 +23,22 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/hashtag")
 public class HashtagController {
 
+    private final HashtagService hashtagService;
+
     @Operation(summary = "[팀 페이지] 해당 팀에 등록된 모든 해시태그 조회")
     @GetMapping("/team-hashtags/{teamId}")
     public ResponseEntity<GetTeamHashtagsVO> getTeamHashtags(@Parameter(description = "특정 팀에 등록되어 있는 모든 해시태그 조회")
                                                        @PathVariable("teamId") Long teamId) {
-        return BaseResponse.ok(GetTeamHashtagsVO.mock());
+        List<HashtagVO> hashtags = hashtagService.findAllHashtag(teamId);
+
+        return BaseResponse.ok(new GetTeamHashtagsVO(hashtags));
     }
 
     @Operation(summary = "[링크 등록 모달] 특정 팀에 새로운 해시태그 생성", description = "'링크 등록' 시 유저가 기존에 존재하던 해시태그 외 새로운 해시태그를 생성했을 경우, 해당 api 로 요청하여 새 해시태그를 등록한다. " +
             "<br> 반환값: 새로 생성된 해시태그 고유 id")
-    @PostMapping()
-    public ResponseEntity<Long> postHashtag(@ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
+    @PostMapping("/team-hashtags/{teamId}")
+    public ResponseEntity<Long> postHashtag(
+            @ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
         return BaseResponse.ok(Long.valueOf(100));
     }
 

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -34,12 +34,16 @@ public class HashtagController {
         return BaseResponse.ok(new GetTeamHashtagsVO(hashtags));
     }
 
+    /**
+     * 우선 POST 요청 성공 시 메세지가 반환되도록 구현. 추후 Long타입으로 바꿔야함.
+     */
     @Operation(summary = "[링크 등록 모달] 특정 팀에 새로운 해시태그 생성", description = "'링크 등록' 시 유저가 기존에 존재하던 해시태그 외 새로운 해시태그를 생성했을 경우, 해당 api 로 요청하여 새 해시태그를 등록한다. " +
             "<br> 반환값: 새로 생성된 해시태그 고유 id")
-    @PostMapping("/team-hashtags/{teamId}")
-    public ResponseEntity<Long> postHashtag(
-            @ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
-        return BaseResponse.ok(Long.valueOf(100));
+    @PostMapping("")
+    public ResponseEntity<String> postHashtag( @ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
+        hashtagService.postHashtagByTeam(postHashtagDTO);
+//        Long newHashtagId = hashtagService.find(postHashtagDTO.get)
+        return BaseResponse.ok("태그 등록 완료");
     }
 
     @Operation(summary = "특정 해시태그를 삭제", description = "'해시태그 고유 id' 를 전송해, 특정 해시태그를 삭제한다.")

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -40,10 +40,9 @@ public class HashtagController {
     @Operation(summary = "[링크 등록 모달] 특정 팀에 새로운 해시태그 생성", description = "'링크 등록' 시 유저가 기존에 존재하던 해시태그 외 새로운 해시태그를 생성했을 경우, 해당 api 로 요청하여 새 해시태그를 등록한다. " +
             "<br> 반환값: 새로 생성된 해시태그 고유 id")
     @PostMapping("")
-    public ResponseEntity<String> postHashtag( @ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
-        hashtagService.postHashtagByTeam(postHashtagDTO);
-//        Long newHashtagId = hashtagService.find(postHashtagDTO.get)
-        return BaseResponse.ok("태그 등록 완료");
+    public ResponseEntity<Long> postHashtag( @ModelAttribute @Valid PostHashtagDTO postHashtagDTO) {
+        HashtagVO newHashtag = hashtagService.postHashtagByTeam(postHashtagDTO);
+        return BaseResponse.ok(newHashtag.hashtagId());
     }
 
     @Operation(summary = "특정 해시태그를 삭제", description = "'해시태그 고유 id' 를 전송해, 특정 해시태그를 삭제한다.")

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/GetTeamHashtagsVO.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/GetTeamHashtagsVO.java
@@ -1,10 +1,13 @@
 package com.kw.LinkIt.domain.hashtag.dto.response;
 
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import java.util.List;
 
 public record GetTeamHashtagsVO(List<HashtagVO> hashtags) {
-    // TODO: mock 데이터 추후 삭제
+
+
     public static GetTeamHashtagsVO mock() {
         return new GetTeamHashtagsVO(HashtagVO.mock());
     }
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/GetTeamHashtagsVO.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/GetTeamHashtagsVO.java
@@ -5,9 +5,4 @@ import java.util.List;
 
 public record GetTeamHashtagsVO(List<HashtagVO> hashtags) {
 
-
-    public static GetTeamHashtagsVO mock() {
-        return new GetTeamHashtagsVO(HashtagVO.mock());
-    }
-
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/HashtagVO.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/HashtagVO.java
@@ -13,20 +13,7 @@ public record HashtagVO(Long hashtagId, String hashtagName) {
                 entity.getName()
         );
     }
-    // TODO: mock 데이터 추후 삭제
-    public static List<HashtagVO> mock() {
-        return new ArrayList<>(Arrays.asList(
-                new HashtagVO(Long.valueOf(1), "flutter"),
-                new HashtagVO(Long.valueOf(2), "state management"),
-                new HashtagVO(Long.valueOf(3), "blog"),
-                new HashtagVO(Long.valueOf(4), "daily"),
-                new HashtagVO(Long.valueOf(5), "enjin"),
-                new HashtagVO(Long.valueOf(6), "apps"),
-                new HashtagVO(Long.valueOf(7), "dev"),
-                new HashtagVO(Long.valueOf(8), "같이에듀"),
-                new HashtagVO(Long.valueOf(9), "학습멘토링")
-        ));
-    }
+
 
 
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/HashtagVO.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/dto/response/HashtagVO.java
@@ -1,10 +1,18 @@
 package com.kw.LinkIt.domain.hashtag.dto.response;
 
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public record HashtagVO(Long hashtagId, String hashtagName) {
+
+    public static HashtagVO of(Hashtag entity) {
+        return new HashtagVO(
+                entity.getId(),
+                entity.getName()
+        );
+    }
     // TODO: mock 데이터 추후 삭제
     public static List<HashtagVO> mock() {
         return new ArrayList<>(Arrays.asList(
@@ -19,4 +27,6 @@ public record HashtagVO(Long hashtagId, String hashtagName) {
                 new HashtagVO(Long.valueOf(9), "학습멘토링")
         ));
     }
+
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/entity/Hashtag.java
@@ -3,6 +3,7 @@ package com.kw.LinkIt.domain.hashtag.entity;
 import com.kw.LinkIt.domain.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class Hashtag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
+
+    @Builder
+    public Hashtag(String name, Team team) {
+        this.name = name;
+        this.team = team;
+    }
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/CustomHashtagRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/CustomHashtagRepository.java
@@ -1,9 +1,11 @@
 package com.kw.LinkIt.domain.hashtag.repository;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import java.util.List;
 import org.springframework.data.repository.query.Param;
 
 public interface CustomHashtagRepository {
     List<Hashtag> findAllByTeam(Long teamId);
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/CustomHashtagRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/CustomHashtagRepository.java
@@ -1,0 +1,9 @@
+package com.kw.LinkIt.domain.hashtag.repository;
+
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import java.util.List;
+import org.springframework.data.repository.query.Param;
+
+public interface CustomHashtagRepository {
+    List<Hashtag> findAllByTeam(Long teamId);
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepository.java
@@ -1,0 +1,18 @@
+package com.kw.LinkIt.domain.hashtag.repository;
+
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    @Query(value =
+            "select ht from Hashtag ht "
+                + "join fetch ht.team "
+                + "where ht.team.id = :teamId"
+    )
+    List<Hashtag> findAllByTeam(@Param("teamId") Long teamId);
+
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.kw.LinkIt.domain.hashtag.repository;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import com.kw.LinkIt.domain.hashtag.entity.QHashtag;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,4 +26,5 @@ public class HashtagRepositoryImpl implements CustomHashtagRepository {
                 .stream()
                 .toList();
     }
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -27,4 +27,6 @@ public class HashtagRepositoryImpl implements CustomHashtagRepository {
                 .toList();
     }
 
+
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.kw.LinkIt.domain.hashtag.repository;
+
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import com.kw.LinkIt.domain.hashtag.entity.QHashtag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.kw.LinkIt.domain.hashtag.entity.QHashtag.hashtag;
+import static com.kw.LinkIt.domain.team.entity.QTeam.team;
+
+@Repository
+@RequiredArgsConstructor
+public class HashtagRepositoryImpl implements CustomHashtagRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Hashtag> findAllByTeam(Long teamId) {
+        return queryFactory
+                .selectFrom(hashtag)
+                .join(hashtag.team, team).fetchJoin()
+                .where(hashtag.team.id.eq(teamId))
+                .stream()
+                .toList();
+    }
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
@@ -1,9 +1,12 @@
 package com.kw.LinkIt.domain.hashtag.service;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
 import java.util.List;
 
 public interface HashtagService {
     List<HashtagVO> findAllHashtag(long teamId);
+
+    void postHashtagByTeam(PostHashtagDTO postHashtagDTO);
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface HashtagService {
     List<HashtagVO> findAllHashtag(long teamId);
 
-    void postHashtagByTeam(PostHashtagDTO postHashtagDTO);
+    HashtagVO postHashtagByTeam(PostHashtagDTO postHashtagDTO);
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,9 @@
+package com.kw.LinkIt.domain.hashtag.service;
+
+import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
+import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
+import java.util.List;
+
+public interface HashtagService {
+    List<HashtagVO> findAllHashtag(long teamId);
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -30,13 +30,13 @@ public class HashtagServiceImpl implements HashtagService {
 
     @Override
     @Transactional
-    public void postHashtagByTeam (PostHashtagDTO postHashtagDTO) {
+    public HashtagVO postHashtagByTeam (PostHashtagDTO postHashtagDTO) {
         Optional<Team> myTeam = teamRepository.findById(postHashtagDTO.getTeamId());
 
-        // TODO : Exception Handling
-        hashtagRepository.save(Hashtag.builder()
-                .name(postHashtagDTO.getHashtagName())
-                .team(myTeam.get())
-                .build());
+        Hashtag newHashtag = hashtagRepository.save(Hashtag.builder()
+                    .name(postHashtagDTO.getHashtagName())
+                    .team(myTeam.orElseThrow())
+                    .build());
+        return new HashtagVO(newHashtag.getId(), newHashtag.getName());
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -1,0 +1,25 @@
+package com.kw.LinkIt.domain.hashtag.service;
+
+import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import com.kw.LinkIt.domain.hashtag.repository.HashtagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagServiceImpl implements HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    public List<HashtagVO> findAllHashtag(long teamId) {
+        List<Hashtag> allHashTags = hashtagRepository.findAllByTeam(teamId);
+
+        return allHashTags.stream()
+                .map(HashtagVO::of)
+                .toList();
+    }
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -1,9 +1,13 @@
 package com.kw.LinkIt.domain.hashtag.service;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
 import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import com.kw.LinkIt.domain.hashtag.repository.HashtagRepository;
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.kw.LinkIt.domain.team.repository.TeamRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class HashtagServiceImpl implements HashtagService {
 
     private final HashtagRepository hashtagRepository;
+    private final TeamRepository teamRepository;
 
     public List<HashtagVO> findAllHashtag(long teamId) {
         List<Hashtag> allHashTags = hashtagRepository.findAllByTeam(teamId);
@@ -21,5 +26,17 @@ public class HashtagServiceImpl implements HashtagService {
         return allHashTags.stream()
                 .map(HashtagVO::of)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public void postHashtagByTeam (PostHashtagDTO postHashtagDTO) {
+        Optional<Team> myTeam = teamRepository.findById(postHashtagDTO.getTeamId());
+
+        // TODO : Exception Handling
+        hashtagRepository.save(Hashtag.builder()
+                .name(postHashtagDTO.getHashtagName())
+                .team(myTeam.get())
+                .build());
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/repository/CustomTeamRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/repository/CustomTeamRepository.java
@@ -1,0 +1,10 @@
+package com.kw.LinkIt.domain.team.repository;
+
+import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+
+public interface CustomTeamRepository {
+    Team findById(Long teamId);
+}

--- a/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.kw.LinkIt.domain.team.repository;
+
+import com.kw.LinkIt.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+}

--- a/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.kw.LinkIt.domain.team.repository;
+
+import static com.kw.LinkIt.domain.team.entity.QTeam.team;
+
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamRepositoryImpl implements CustomTeamRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Team findById(Long teamId) {
+        return queryFactory
+                .selectFrom(team)
+                .where(team.id.eq(teamId))
+                .fetchOne();
+    }
+
+}

--- a/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
@@ -26,7 +26,10 @@ public class SecurityConfig {
             "/webjars/**",
 
             //auth
-            "/auth/sign-up", "/auth/login"
+            "/auth/sign-up", "/auth/login",
+
+            //hashtag
+            "/hashtag/**"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/kw/LinkIt/global/config/WebConfig.java
+++ b/src/main/java/com/kw/LinkIt/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.kw.LinkIt.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() { return new JPAQueryFactory(entityManager); }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Hashtag API를 구현하였습니다.
- [x] GET : `getTeamHashtags` 구현 완료
- [x] POST : `postHashtag` 80% 완료 (등록된 태그에 대해 예외처리 및 id 반환 기능 미완료)
- [ ] DELETE : 미완료

* **커밋 라벨을 잘못올렸네요...죄송합니다.**

## 📋 변경 사항
`HashtagController`
`HashtagVO` -> of 메소드 구현,
`Hashtag` -> 빌더 코드 구현
#### repository
`CustomHashtagRepository`, `HashtagRepository`, `HashtagRepositoryImpl`
#### service
`HashtagService`, `HashtagServiceImpl`

### global
`build.gradle` -> queryDSL 의존성 추가
`webconfig` -> queryDSL 관련 Config 추가
 

## 🔥 연결된 이슈 Close
Not closing

