### PR TITLE
Fix: 링크 등록/수정 관련 DTO 수정

### DIFF
--- a/src/main/java/com/kw/LinkIt/domain/link/dto/request/PostLinkDTO.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/dto/request/PostLinkDTO.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -19,7 +18,7 @@ public class PostLinkDTO {
 
     private String content;
 
-    private MultipartFile previewImg;
+    private String previewImgUrl;
 
     @NotNull
     private Long teamId;

--- a/src/main/java/com/kw/LinkIt/domain/link/dto/request/PostLinkDTO.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/dto/request/PostLinkDTO.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,4 +24,6 @@ public class PostLinkDTO {
 
     @NotNull
     private Long teamId;
+
+    private List<String> hashtagNames;
 }

--- a/src/main/java/com/kw/LinkIt/domain/link/dto/request/UpdateLinkDTO.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/dto/request/UpdateLinkDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -18,5 +17,5 @@ public class UpdateLinkDTO {
 
     private String content;
 
-    private MultipartFile previewImg;
+    private String previewImgUrl;
 }

--- a/src/main/java/com/kw/LinkIt/domain/link/dto/request/UpdateLinkDTO.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/dto/request/UpdateLinkDTO.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,4 +20,6 @@ public class UpdateLinkDTO {
     private String content;
 
     private String previewImgUrl;
+
+    private List<String> hashtagNames;
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 링크 등록/수정 시 preview image 의 타입을 MultipartFile -> String 으로 변경합니다.
- 링크 등록/수정 DTO 에 `해시태그 리스트` 를 추가합니다.

## 📋 변경 사항
- `PostLinkDTO`
- `UpdateLinkDTO`

## 🔥 연결된 이슈 Close

