### PR TITLE
Fix: '특정 팀의 모든 해시태그 조회' 시, 해시태그 이름 string list 로 반환받을 수 있도록 수정 (#23)

### DIFF
--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -3,7 +3,6 @@ package com.kw.LinkIt.domain.hashtag.controller;
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
-import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import com.kw.LinkIt.domain.hashtag.service.HashtagService;
 import com.kw.LinkIt.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,11 +26,10 @@ public class HashtagController {
 
     @Operation(summary = "[팀 페이지] 해당 팀에 등록된 모든 해시태그 조회")
     @GetMapping("/team-hashtags/{teamId}")
-    public ResponseEntity<GetTeamHashtagsVO> getTeamHashtags(@Parameter(description = "특정 팀에 등록되어 있는 모든 해시태그 조회")
+    public ResponseEntity<List<String>> getTeamHashtags(@Parameter(description = "특정 팀에 등록되어 있는 모든 해시태그 조회")
                                                        @PathVariable("teamId") Long teamId) {
-        List<HashtagVO> hashtags = hashtagService.findAllHashtag(teamId);
-
-        return BaseResponse.ok(new GetTeamHashtagsVO(hashtags));
+        List<String> hashtagNames = hashtagService.findAllHashtagNames(teamId);
+        return BaseResponse.ok(hashtagNames);
     }
 
     /**

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
@@ -1,12 +1,11 @@
 package com.kw.LinkIt.domain.hashtag.service;
 
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
-import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
 import java.util.List;
 
 public interface HashtagService {
-    List<HashtagVO> findAllHashtag(long teamId);
+    List<String> findAllHashtagNames(long teamId);
 
     HashtagVO postHashtagByTeam(PostHashtagDTO postHashtagDTO);
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -8,6 +8,8 @@ import com.kw.LinkIt.domain.team.entity.Team;
 import com.kw.LinkIt.domain.team.repository.TeamRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,12 +22,9 @@ public class HashtagServiceImpl implements HashtagService {
     private final HashtagRepository hashtagRepository;
     private final TeamRepository teamRepository;
 
-    public List<HashtagVO> findAllHashtag(long teamId) {
+    public List<String> findAllHashtagNames(long teamId) {
         List<Hashtag> allHashTags = hashtagRepository.findAllByTeam(teamId);
-
-        return allHashTags.stream()
-                .map(HashtagVO::of)
-                .toList();
+        return allHashTags.stream().map(Hashtag::getName).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 프론트 측 요청에 따라, '특정 팀의 모든 해시태그 조회' 시, 해시태그 이름 string list 로 반환받을 수 있도록 수정합니다.

## 📋 변경 사항

## 🔥 연결된 이슈 Close

