### PR TITLE
Feat: Hashtag DELETE / Team POST, GET api 구현

### DIFF
--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -1,5 +1,6 @@
 package com.kw.LinkIt.domain.hashtag.controller;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.DeleteHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.GetTeamHashtagsVO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
@@ -46,6 +47,7 @@ public class HashtagController {
     @Operation(summary = "특정 해시태그를 삭제", description = "'해시태그 고유 id' 를 전송해, 특정 해시태그를 삭제한다.")
     @DeleteMapping("/{hashtagId}")
     public ResponseEntity<String> deleteHashtag(@PathVariable("hashtagId") Long hashtagId) {
+        hashtagService.deleteHashtag(new DeleteHashtagDTO(hashtagId));
         return BaseResponse.ok("해시태그 삭제 성공");
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/controller/HashtagController.java
@@ -33,9 +33,7 @@ public class HashtagController {
         return BaseResponse.ok(hashtagNames);
     }
 
-    /**
-     * 우선 POST 요청 성공 시 메세지가 반환되도록 구현. 추후 Long타입으로 바꿔야함.
-     */
+
     @Operation(summary = "[링크 등록 모달] 특정 팀에 새로운 해시태그 생성", description = "'링크 등록' 시 유저가 기존에 존재하던 해시태그 외 새로운 해시태그를 생성했을 경우, 해당 api 로 요청하여 새 해시태그를 등록한다. " +
             "<br> 반환값: 새로 생성된 해시태그 고유 id")
     @PostMapping("")

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/dto/request/DeleteHashtagDTO.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/dto/request/DeleteHashtagDTO.java
@@ -1,0 +1,16 @@
+package com.kw.LinkIt.domain.hashtag.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DeleteHashtagDTO {
+    @NotNull
+    private long hashtagId;
+}

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/repository/HashtagRepositoryImpl.java
@@ -26,7 +26,4 @@ public class HashtagRepositoryImpl implements CustomHashtagRepository {
                 .stream()
                 .toList();
     }
-
-
-
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagService.java
@@ -1,5 +1,6 @@
 package com.kw.LinkIt.domain.hashtag.service;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.DeleteHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
 import java.util.List;
@@ -8,4 +9,7 @@ public interface HashtagService {
     List<String> findAllHashtagNames(long teamId);
 
     HashtagVO postHashtagByTeam(PostHashtagDTO postHashtagDTO);
+
+    void deleteHashtag(DeleteHashtagDTO deleteHashtagDTO);
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -1,9 +1,11 @@
 package com.kw.LinkIt.domain.hashtag.service;
 
+import com.kw.LinkIt.domain.hashtag.dto.request.DeleteHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.request.PostHashtagDTO;
 import com.kw.LinkIt.domain.hashtag.dto.response.HashtagVO;
 import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import com.kw.LinkIt.domain.hashtag.repository.HashtagRepository;
+import com.kw.LinkIt.domain.linkHashtag.repository.LinkHashtagRepository;
 import com.kw.LinkIt.domain.team.entity.Team;
 import com.kw.LinkIt.domain.team.repository.TeamRepository;
 import java.util.List;
@@ -21,6 +23,7 @@ public class HashtagServiceImpl implements HashtagService {
 
     private final HashtagRepository hashtagRepository;
     private final TeamRepository teamRepository;
+    private final LinkHashtagRepository linkHashtagRepository;
 
     public List<String> findAllHashtagNames(long teamId) {
         List<Hashtag> allHashTags = hashtagRepository.findAllByTeam(teamId);
@@ -37,5 +40,12 @@ public class HashtagServiceImpl implements HashtagService {
                     .team(myTeam.orElseThrow())
                     .build());
         return new HashtagVO(newHashtag.getId(), newHashtag.getName());
+    }
+
+    @Override
+    @Transactional
+    public void deleteHashtag(DeleteHashtagDTO deleteHashtagDTO) {
+        hashtagRepository.deleteById(deleteHashtagDTO.getHashtagId());
+        linkHashtagRepository.deleteAllByHashtag(deleteHashtagDTO.getHashtagId());
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class HashtagServiceImpl implements HashtagService {
 
     private final HashtagRepository hashtagRepository;

--- a/src/main/java/com/kw/LinkIt/domain/linkHashtag/repository/LinkHashtagRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/linkHashtag/repository/LinkHashtagRepository.java
@@ -4,6 +4,7 @@ import com.kw.LinkIt.domain.link.entity.Link;
 import com.kw.LinkIt.domain.linkHashtag.entity.LinkHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,4 +16,11 @@ public interface LinkHashtagRepository extends JpaRepository<LinkHashtag, Long> 
     List<LinkHashtag> findAllByTeamIdAndHastagName(Long teamId, String hashtagName);
 
     void deleteAllByLink(Link link);
+
+    @Query(
+            "delete from LinkHashtag lnht "
+                    + "where lnht.hashtag.id = :hashtagId"
+    )
+    void deleteAllByHashtag(@Param("hashtagId") Long hashtagId);
+
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/controller/TeamController.java
@@ -3,12 +3,16 @@ package com.kw.LinkIt.domain.team.controller;
 import com.kw.LinkIt.domain.team.dto.request.CreateTeamDTO;
 import com.kw.LinkIt.domain.team.dto.request.UpdateTeamProfileDTO;
 import com.kw.LinkIt.domain.team.dto.response.AppbarTeamInfoVO;
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.kw.LinkIt.domain.team.service.TeamService;
+import com.kw.LinkIt.domain.user.entity.User;
 import com.kw.LinkIt.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,10 +23,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/team")
 public class TeamController {
 
+    private final TeamService teamService;
+
     @Operation(summary = "팀 생성")
     @PostMapping
-    public ResponseEntity<String> createTeam(@ModelAttribute @Valid CreateTeamDTO createTeamDTO) {
-        teamService.createTeam(createTeamDTO);
+    public ResponseEntity<String> createTeam(@ModelAttribute @Valid CreateTeamDTO createTeamDTO, @AuthenticationPrincipal User user) {
+        teamService.createTeam(createTeamDTO, user);
         return BaseResponse.ok("팀 생성 완료");
     }
 
@@ -35,6 +41,7 @@ public class TeamController {
     @Operation(summary = "appbar 에 표시해줄 팀 정보 반환")
     @GetMapping("/app-bar/{teamId}")
     public ResponseEntity<AppbarTeamInfoVO> getAppbarTeamInfo(@PathVariable("teamId") Long teamId) {
-        return BaseResponse.ok(AppbarTeamInfoVO.mock());
+        Team team = teamService.getTeam(teamId);
+        return BaseResponse.ok(new AppbarTeamInfoVO(team.getName(), team.getProfileImg()));
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/controller/TeamController.java
@@ -22,6 +22,7 @@ public class TeamController {
     @Operation(summary = "팀 생성")
     @PostMapping
     public ResponseEntity<String> createTeam(@ModelAttribute @Valid CreateTeamDTO createTeamDTO) {
+        teamService.createTeam(createTeamDTO);
         return BaseResponse.ok("팀 생성 완료");
     }
 

--- a/src/main/java/com/kw/LinkIt/domain/team/entity/Team.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/entity/Team.java
@@ -3,6 +3,7 @@ package com.kw.LinkIt.domain.team.entity;
 import com.kw.LinkIt.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +25,12 @@ public class Team {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id")
     private User leader;
+
+    @Builder
+    public Team(String name, String profileImg, Integer capacity, User leader) {
+        this.name = name;
+        this.profileImg = profileImg;
+        this.capacity = capacity;
+        this.leader = leader;
+    }
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/repository/TeamRepository.java
@@ -2,8 +2,10 @@ package com.kw.LinkIt.domain.team.repository;
 
 import com.kw.LinkIt.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findById(Long id);

--- a/src/main/java/com/kw/LinkIt/domain/team/service/TeamService.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/service/TeamService.java
@@ -1,0 +1,8 @@
+package com.kw.LinkIt.domain.team.service;
+
+import com.kw.LinkIt.domain.team.dto.request.CreateTeamDTO;
+
+public interface TeamService {
+    CreateTeamDTO create
+
+}

--- a/src/main/java/com/kw/LinkIt/domain/team/service/TeamService.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/service/TeamService.java
@@ -1,8 +1,11 @@
 package com.kw.LinkIt.domain.team.service;
 
 import com.kw.LinkIt.domain.team.dto.request.CreateTeamDTO;
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.kw.LinkIt.domain.user.entity.User;
 
 public interface TeamService {
-    CreateTeamDTO create
+    void createTeam(CreateTeamDTO createTeamDTO, User user);
 
+    Team getTeam(Long teamId);
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/service/TeamServiceImpl.java
@@ -1,4 +1,30 @@
 package com.kw.LinkIt.domain.team.service;
 
-public class TeamServiceImpl {
+import com.kw.LinkIt.domain.team.dto.request.CreateTeamDTO;
+import com.kw.LinkIt.domain.team.entity.Team;
+import com.kw.LinkIt.domain.team.repository.TeamRepository;
+import com.kw.LinkIt.domain.user.entity.User;
+import com.kw.LinkIt.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamServiceImpl implements TeamService {
+
+    private final TeamRepository teamRepository;
+    public void createTeam(CreateTeamDTO createTeamDTO, User user) {
+        teamRepository.save(Team.builder()
+                        .name(createTeamDTO.getName())
+                        .profileImg(createTeamDTO.getProfileImgUrl())
+                        .capacity(createTeamDTO.getCapacity())
+                        .leader(user)
+                        .build());
+    }
+
+    public Team getTeam(Long teamId) {
+        return teamRepository.findById(teamId).orElseThrow();
+    }
 }

--- a/src/main/java/com/kw/LinkIt/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/team/service/TeamServiceImpl.java
@@ -1,0 +1,4 @@
+package com.kw.LinkIt.domain.team.service;
+
+public class TeamServiceImpl {
+}

--- a/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
@@ -29,7 +29,11 @@ public class SecurityConfig {
             "/auth/sign-up", "/auth/login",
 
             //hashtag
-            "/hashtag/**"
+            "/hashtag",
+            "/hashtag/**",
+
+            //linkHashtag
+            "/link"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/kw/LinkIt/global/config/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
             "/hashtag",
             "/hashtag/**",
 
-            //linkHashtag
-            "/link"
+            //teams
+            "/team/**"
     };
 
     private final JwtTokenProvider jwtTokenProvider;


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Hashtag DELETE / Team POST, GET api 구현하였습니다.

## 📋 변경 사항
`HashtagService`, `HashtagController`,
`TeamController`, `TeamService`, `Team`, `TeamRepository`, `TeamServiceImpl`

`SecurityConfing`

## 🔥 연결된 이슈 Close
close #23
