### PR TITLE
Feat: 좋아요 관련 API 구현 (#29)

### DIFF
--- a/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
+++ b/src/main/java/com/kw/LinkIt/domain/hashtag/service/HashtagServiceImpl.java
@@ -66,8 +66,8 @@ public class HashtagServiceImpl implements HashtagService {
     @Override
     @Transactional
     public void deleteHashtag(DeleteHashtagDTO deleteHashtagDTO) {
+        linkHashtagRepository.deleteAllByHashtagId(deleteHashtagDTO.getHashtagId());
         hashtagRepository.deleteById(deleteHashtagDTO.getHashtagId());
-        linkHashtagRepository.deleteAllByHashtag(deleteHashtagDTO.getHashtagId());
     }
 
     private List<String> findAllHashtagNamesOfTeam(Team team) {

--- a/src/main/java/com/kw/LinkIt/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/controller/LikesController.java
@@ -27,7 +27,8 @@ public class LikesController {
 
     @Operation(summary = "링크에 좋아요 취소")
     @DeleteMapping("/{linkId}")
-    public ResponseEntity<String> deleteLike(@PathVariable("linkId") Long linkId) {
+    public ResponseEntity<String> deleteLike(@PathVariable("linkId") Long linkId, @AuthenticationPrincipal User user) {
+        likesService.deleteLike(linkId,user);
         return BaseResponse.ok("좋아요 취소 완료");
     }
 }

--- a/src/main/java/com/kw/LinkIt/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/controller/LikesController.java
@@ -1,10 +1,13 @@
 package com.kw.LinkIt.domain.likes.controller;
 
+import com.kw.LinkIt.domain.likes.service.LikesService;
+import com.kw.LinkIt.domain.user.entity.User;
 import com.kw.LinkIt.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Likes")
@@ -13,9 +16,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/likes")
 public class LikesController {
 
+    private final LikesService likesService;
+
     @Operation(summary = "링크에 좋아요 누르기")
     @PostMapping("/{linkId}")
-    public ResponseEntity<String> postLike(@PathVariable("linkId") Long linkId) {
+    public ResponseEntity<String> postLike(@PathVariable("linkId") Long linkId, @AuthenticationPrincipal User user) {
+        likesService.postLike(linkId,user);
         return BaseResponse.ok("좋아요 누르기 완료");
     }
 

--- a/src/main/java/com/kw/LinkIt/domain/likes/entity/Likes.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/entity/Likes.java
@@ -4,6 +4,7 @@ import com.kw.LinkIt.domain.link.entity.Link;
 import com.kw.LinkIt.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class Likes {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public Likes(Link link, User user) {
+        this.link = link;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/kw/LinkIt/domain/likes/error/LikesErrorCode.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/error/LikesErrorCode.java
@@ -1,0 +1,16 @@
+package com.kw.LinkIt.domain.likes.error;
+
+import com.kw.LinkIt.global.error.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LikesErrorCode implements ErrorCode {
+    LIKES_ALREADY_PRESSED(HttpStatus.BAD_REQUEST, "Likes-001", "이미 좋아요를 누른 링크입니다.");
+
+    private HttpStatus status;
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/kw/LinkIt/domain/likes/error/LikesErrorCode.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/error/LikesErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum LikesErrorCode implements ErrorCode {
-    LIKES_ALREADY_PRESSED(HttpStatus.BAD_REQUEST, "Likes-001", "이미 좋아요를 누른 링크입니다.");
+    LIKES_ALREADY_PRESSED(HttpStatus.BAD_REQUEST, "Likes-001", "이미 좋아요를 누른 링크입니다."),
+    LIKES_NOT_PRESSED_YET(HttpStatus.BAD_REQUEST, "Likes-002", "좋아요를 누른 적 없는 링크입니다.");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/com/kw/LinkIt/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/repository/LikesRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
     boolean existsByUserAndLink(User user, Link link);
+    void deleteByUserAndLink(User user, Link link);
 }

--- a/src/main/java/com/kw/LinkIt/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/repository/LikesRepository.java
@@ -1,0 +1,10 @@
+package com.kw.LinkIt.domain.likes.repository;
+
+import com.kw.LinkIt.domain.likes.entity.Likes;
+import com.kw.LinkIt.domain.link.entity.Link;
+import com.kw.LinkIt.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+    boolean existsByUserAndLink(User user, Link link);
+}

--- a/src/main/java/com/kw/LinkIt/domain/likes/service/LikesService.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/service/LikesService.java
@@ -34,6 +34,17 @@ public class LikesService {
                 .build());
     }
 
+    @Transactional
+    public void deleteLike(Long linkId, User user) {
+        Link link = getLink(linkId);
+
+        if(!likesRepository.existsByUserAndLink(user,link)) {
+            throw new BusinessException(LikesErrorCode.LIKES_NOT_PRESSED_YET);
+        }
+
+        likesRepository.deleteByUserAndLink(user,link);
+    }
+
     private Link getLink(Long linkId) {
         return linkRepository.findById(linkId).orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
     }

--- a/src/main/java/com/kw/LinkIt/domain/likes/service/LikesService.java
+++ b/src/main/java/com/kw/LinkIt/domain/likes/service/LikesService.java
@@ -1,0 +1,40 @@
+package com.kw.LinkIt.domain.likes.service;
+
+import com.kw.LinkIt.domain.likes.entity.Likes;
+import com.kw.LinkIt.domain.likes.error.LikesErrorCode;
+import com.kw.LinkIt.domain.likes.repository.LikesRepository;
+import com.kw.LinkIt.domain.link.entity.Link;
+import com.kw.LinkIt.domain.link.repository.LinkRepository;
+import com.kw.LinkIt.domain.user.entity.User;
+import com.kw.LinkIt.global.error.code.CommonErrorCode;
+import com.kw.LinkIt.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikesService {
+
+    private final LikesRepository likesRepository;
+    private final LinkRepository linkRepository;
+
+    @Transactional
+    public void postLike(Long linkId, User user) {
+        Link link = getLink(linkId);
+
+        if (likesRepository.existsByUserAndLink(user,link)) {
+            throw new BusinessException(LikesErrorCode.LIKES_ALREADY_PRESSED);
+        }
+
+        likesRepository.save(Likes.builder()
+                .link(link)
+                .user(user)
+                .build());
+    }
+
+    private Link getLink(Long linkId) {
+        return linkRepository.findById(linkId).orElseThrow(() -> new BusinessException(CommonErrorCode.NOT_FOUND));
+    }
+}

--- a/src/main/java/com/kw/LinkIt/domain/link/controller/LinkController.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/controller/LinkController.java
@@ -29,8 +29,8 @@ public class LinkController {
     @GetMapping("/team-links/{teamId}")
     public ResponseEntity<GetTeamLinksVO> getTeamLinks(@PathVariable("teamId") Long teamId,
                                                        @Parameter(description = "특정 해시태그에 대해 검색하고 싶을 경우 해시태그 이름 입력 (입력하지 않을 경우, 전체 링크 조회)")
-                                                           @RequestParam(required = false) String hashtagName) {
-        GetTeamLinksVO getTeamLinksVO = linkService.getTeamLinks(teamId, hashtagName);
+                                                           @RequestParam(required = false) String hashtagName, @AuthenticationPrincipal User user) {
+        GetTeamLinksVO getTeamLinksVO = linkService.getTeamLinks(teamId, hashtagName, user);
         return BaseResponse.ok(getTeamLinksVO);
     }
 

--- a/src/main/java/com/kw/LinkIt/domain/link/dto/response/LinkVO.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/dto/response/LinkVO.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record LinkVO(UserVO userVO, String title, String content, String linkPreviewImg, List<String> tags, String url) {
+public record LinkVO(UserVO userVO, String title, String content, String linkPreviewImg, List<String> tags, String url, Boolean isLikePressed) {
     // TODO: mock 데이터 추후 삭제
 //    public static List<LinkVO> mock() {
 //        return new ArrayList<>(Arrays.asList(

--- a/src/main/java/com/kw/LinkIt/domain/link/service/LinkService.java
+++ b/src/main/java/com/kw/LinkIt/domain/link/service/LinkService.java
@@ -2,6 +2,7 @@ package com.kw.LinkIt.domain.link.service;
 
 import com.kw.LinkIt.domain.hashtag.entity.Hashtag;
 import com.kw.LinkIt.domain.hashtag.repository.HashtagRepository;
+import com.kw.LinkIt.domain.likes.repository.LikesRepository;
 import com.kw.LinkIt.domain.link.dto.request.PostLinkDTO;
 import com.kw.LinkIt.domain.link.dto.response.GetTeamLinksVO;
 import com.kw.LinkIt.domain.link.dto.response.LinkVO;
@@ -32,8 +33,9 @@ public class LinkService {
     private final LinkHashtagRepository linkHashtagRepository;
     private final TeamRepository teamRepository;
     private final HashtagRepository hashtagRepository;
+    private final LikesRepository likesRepository;
 
-    public GetTeamLinksVO getTeamLinks(Long teamId, String hashtagName) {
+    public GetTeamLinksVO getTeamLinks(Long teamId, String hashtagName, User user) {
         Team team = getTeam(teamId);
         List<LinkVO> linkVOs;
 
@@ -48,7 +50,8 @@ public class LinkService {
                                 link.getContent(),
                                 link.getPreviewImg(),
                                 hashtags,
-                                link.getUrl());
+                                link.getUrl(),
+                                isLikePressed(link,user));
                     }).collect(Collectors.toList());
             return new GetTeamLinksVO(team.getName(), linkVOs, links.size());
         }
@@ -64,7 +67,8 @@ public class LinkService {
                             link.getContent(),
                             link.getPreviewImg(),
                             hashtags,
-                            link.getUrl());
+                            link.getUrl(),
+                            isLikePressed(link,user));
                 }).collect(Collectors.toList());
         return new GetTeamLinksVO(team.getName(), linkVOs, links.size());
     }
@@ -123,6 +127,13 @@ public class LinkService {
             Hashtag hashtag = linkHashtag.getHashtag();
             return hashtag.getName();
         }).collect(Collectors.toList());
+    }
+
+    private Boolean isLikePressed(Link link, User user) {
+        if (likesRepository.existsByUserAndLink(user,link)) {
+            return true;
+        }
+        return false;
     }
 
     private void validateOwnershipOfLink(Link link, User user) {

--- a/src/main/java/com/kw/LinkIt/domain/linkHashtag/repository/LinkHashtagRepository.java
+++ b/src/main/java/com/kw/LinkIt/domain/linkHashtag/repository/LinkHashtagRepository.java
@@ -17,11 +17,7 @@ public interface LinkHashtagRepository extends JpaRepository<LinkHashtag, Long> 
 
     void deleteAllByLink(Link link);
 
-    @Query(
-            "delete from LinkHashtag lnht "
-                    + "where lnht.hashtag.id = :hashtagId"
-    )
-    void deleteAllByHashtag(@Param("hashtagId") Long hashtagId);
+    void deleteAllByHashtagId(@Param("hashtagId") Long hashtagId);
 
     List<LinkHashtag> findAllByLink(Link link);
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- Likes 도메인 관련 API 들을 구현합니다.

## 📋 변경 사항
- `LikesController`
    - `postLike`
    - `deleteLike`
- `LinkController`
    - `getTeamLinks`

## 🔥 연결된 이슈 Close
close #29

